### PR TITLE
Use `io.ReadCloser` instead of `io.Reader` for forwarding functions.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/coreos/go-iptables v0.7.0
 	github.com/mdlayher/vsock v1.2.1
 	github.com/milosgajdos/tenus v0.0.3
+	golang.org/x/net v0.20.0
 	golang.org/x/sys v0.16.0
 )
 
 require (
 	github.com/docker/libcontainer v2.2.1+incompatible // indirect
 	github.com/mdlayher/socket v0.5.0 // indirect
-	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 )

--- a/nat.go
+++ b/nat.go
@@ -22,7 +22,7 @@ func ToggleNAT(toggle bool) error {
 	}
 
 	f := t.AppendUnique
-	if toggle == Off {
+	if !toggle {
 		f = t.DeleteIfExists
 	}
 

--- a/proxy.go
+++ b/proxy.go
@@ -18,7 +18,7 @@ const (
 // TCP-over-VSOCK connection. The function keeps on forwarding packets until we
 // encounter an error or EOF. Errors (including EOF) are written to the given
 // channel.
-func TunToVsock(from io.Reader, to io.WriteCloser, ch chan error, wg *sync.WaitGroup) {
+func TunToVsock(from io.ReadCloser, to io.WriteCloser, ch chan error, wg *sync.WaitGroup) {
 	defer to.Close()
 	defer wg.Done()
 	var (
@@ -50,7 +50,7 @@ func TunToVsock(from io.Reader, to io.WriteCloser, ch chan error, wg *sync.WaitG
 // the tun interface. The function keeps on forwarding packets until we
 // encounter an error or EOF. Errors (including EOF) are written to the given
 // channel.
-func VsockToTun(from io.Reader, to io.WriteCloser, ch chan error, wg *sync.WaitGroup) {
+func VsockToTun(from io.ReadCloser, to io.WriteCloser, ch chan error, wg *sync.WaitGroup) {
 	defer to.Close()
 	defer wg.Done()
 	var (

--- a/proxy.go
+++ b/proxy.go
@@ -33,7 +33,7 @@ func TunToVsock(from io.ReadCloser, to io.WriteCloser, ch chan error, wg *sync.W
 		if nr > 0 {
 			// Forward the network packet to our TCP-over-VSOCK connection.
 			binary.BigEndian.PutUint16(pktLenBuf, uint16(nr))
-			if _, werr := to.Write(append(pktLenBuf, pktBuf[:nr]...)); err != nil {
+			if _, werr := to.Write(append(pktLenBuf, pktBuf[:nr]...)); werr != nil {
 				err = werr
 				break
 			}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -68,7 +68,7 @@ func TestAToB(t *testing.T) {
 	assertEq(t, err, nil)
 
 	wg.Add(2)
-	go TunToVsock(bytes.NewReader(sendBuf), conn1, ch, &wg)
+	go TunToVsock(io.NopCloser(bytes.NewReader(sendBuf)), conn1, ch, &wg)
 	go VsockToTun(conn2, recvBuf, ch, &wg)
 	wg.Wait()
 


### PR DESCRIPTION
This lets the caller cancel the two functions when needed.